### PR TITLE
Add missing var init in string index example

### DIFF
--- a/cours_python.pss
+++ b/cours_python.pss
@@ -203,6 +203,7 @@ Accès à un caractère par index
    0   1   2   3   4
   -5  -4  -3  -2  -1
 </pre>
+    >>> word = 'salut'
     >>> word[4]
     't'
     >>> word[-2]


### PR DESCRIPTION
The audience was a bit confused, because the var was not bound earlier to the value used in the slide.