### PR TITLE
Fix typo

### DIFF
--- a/exercices.pss
+++ b/exercices.pss
@@ -291,7 +291,7 @@ _nom, numero, nom\_rue, code\_postal, nom\_ville_ :
 Les afficher au format
 
     Jean Dupont
-    5, rue des Postes
+    5 rue des Postes
     75003 Paris
 
 @pause


### PR DESCRIPTION
The exercice's statement shows a comma, but the various corrections do not.

This is conformant with https://www.laposte.fr/particulier/courriers-colis/conseils-pratiques/bien-rediger-l-adresse-d-une-lettre-ou-d-un-colis .